### PR TITLE
Add Sign Up Screen

### DIFF
--- a/LAKMobile/App.tsx
+++ b/LAKMobile/App.tsx
@@ -1,7 +1,7 @@
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, View } from 'react-native';
-import ScreenHeader from './src/components/ScreenHeader';
-import LoginScreen from './src/screens/LoginScreen';
+import { ScreenHeader } from './src/components';
+import { SignupScreen, LoginScreen } from './src/screens';
 
 export default function App() {
   return (

--- a/LAKMobile/src/components/AppText.tsx
+++ b/LAKMobile/src/components/AppText.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StyleSheet, Text, TextProps } from 'react-native';
+
+export default function AppText({style, children, ...props}: TextProps) {
+    return (
+      <Text 
+        {...props}
+        style={[defaultStyles.textStyle, style]}
+        >{children}</Text>
+    )
+}
+
+const defaultStyles = StyleSheet.create({
+  textStyle: {
+    fontFamily: 'Roboto',
+    fontSize: 18,
+  },
+});

--- a/LAKMobile/src/components/LabelWrapper.tsx
+++ b/LAKMobile/src/components/LabelWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
-import { StyleSheet, Text, View, StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import AppText from './AppText';
 
 type LabelWrapperProps = {
     label: string,
@@ -9,7 +10,7 @@ type LabelWrapperProps = {
 export default function LabelWrapper({label, children}: LabelWrapperProps) {
   return (
     <View style={styles.container}>
-        <Text style={styles.label}>{label}</Text>
+        <AppText style={styles.label}>{label}</AppText>
         {children}
     </View>
   )
@@ -20,7 +21,6 @@ const styles = StyleSheet.create({
         width: '100%'
     },
     label: {
-        marginBottom: 4,
-        fontSize: 18
+        marginBottom: 8,
     },
 })

--- a/LAKMobile/src/components/PrimaryButton.tsx
+++ b/LAKMobile/src/components/PrimaryButton.tsx
@@ -1,5 +1,6 @@
 
-import { StyleSheet, Text, View, Button, TouchableOpacity, StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, TouchableOpacity, StyleProp, ViewStyle } from 'react-native';
+import AppText from './AppText';
 import { COLORS } from '../../constants';
 
 type PrimaryButtonProps = {
@@ -19,7 +20,7 @@ export default function PrimaryButton({title, style, onPress, type}: PrimaryButt
     <TouchableOpacity 
         onPress={onPress} 
         style={[buttonStyle.container, style]}>
-        <Text style={buttonStyle.text}>{title}</Text>
+        <AppText style={buttonStyle.text}>{title}</AppText>
     </TouchableOpacity>
   )
 }
@@ -40,7 +41,6 @@ const defaultStyle = StyleSheet.create({
         // Shared
         fontWeight: "bold",
         alignSelf: "center",
-        fontSize: 20,
 
         color: COLORS.maroon
     },
@@ -59,7 +59,6 @@ const primaryStyle = StyleSheet.create({
         //Shared
         fontWeight: "bold",
         alignSelf: "center",
-        fontSize: 20,
 
         color: COLORS.white,
     }
@@ -73,7 +72,6 @@ const linkStyle = StyleSheet.create({
         // Shared
         fontWeight: "bold",
         alignSelf: "center", 
-        fontSize: 16,
 
         color: COLORS.turquoise,
     }

--- a/LAKMobile/src/components/ScreenHeader.tsx
+++ b/LAKMobile/src/components/ScreenHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import AppText from './AppText';
 import { COLORS } from '../../constants';
 
 interface HeaderProps {
@@ -18,7 +19,7 @@ export default function ScreenHeader({children, showArrow = false}:HeaderProps) 
                     </TouchableOpacity>
                 : null}
 
-                <Text style={styles.headerText}>{children}</Text>
+                <AppText style={styles.headerText}>{children}</AppText>
             </View>
         </View>
     )

--- a/LAKMobile/src/components/index.tsx
+++ b/LAKMobile/src/components/index.tsx
@@ -1,3 +1,5 @@
+import AppText from "./AppText";
 import PrimaryButton from "./PrimaryButton";
 import LabelWrapper from "./LabelWrapper";
-export { PrimaryButton, LabelWrapper }
+import ScreenHeader from "./ScreenHeader";
+export { AppText, PrimaryButton, LabelWrapper, ScreenHeader }

--- a/LAKMobile/src/screens/LoginScreen.tsx
+++ b/LAKMobile/src/screens/LoginScreen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { StyleSheet, Text, TextInput, View } from 'react-native';
-import LabelWrapper from '../components/LabelWrapper';
-import PrimaryButton from '../components/PrimaryButton';
+import { StyleSheet, TextInput, View } from 'react-native';
+import { AppText, LabelWrapper, PrimaryButton } from '../components';
 import { COLORS } from '../../constants';
 
 export default function LoginScreen() {
@@ -35,7 +34,7 @@ export default function LoginScreen() {
             />
 
             <View style={styles.signupPrompt}>
-                <Text style={styles.signupText}>Don't have an account?</Text>
+                <AppText>Don't have an account?</AppText>
                 <PrimaryButton 
                     type='link' 
                     title='Sign up here.' 
@@ -81,10 +80,6 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "flex-start"
-    },
-
-    signupText: {
-        fontSize: 18,
     },
 
     signupLink: {

--- a/LAKMobile/src/screens/SignupScreen.tsx
+++ b/LAKMobile/src/screens/SignupScreen.tsx
@@ -51,8 +51,8 @@ export default function SignupScreen({}) {
         <Text>Already have an account?</Text>
         <PrimaryButton 
           type='link' 
-          title='Log on here' 
-          onPress={() => console.log('Log on here pressed')}
+          title='Log in here' 
+          onPress={() => console.log('Log in here pressed')}
           style={styles.loginLink}
           />
       </View>
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
     marginBottom: 1,
   },
 
-  // Styling for "Log on here" components
+  // Styling for "Log in here" components
   loginLinkContainer: {
     display: 'flex',
     flexDirection: 'row',

--- a/LAKMobile/src/screens/SignupScreen.tsx
+++ b/LAKMobile/src/screens/SignupScreen.tsx
@@ -29,7 +29,7 @@ export default function SignupScreen({}) {
       <LabelWrapper label='4 digit pin password'>
         <TextInput
           style={smallInputStyle}
-          keyboardType="default"
+          keyboardType="numeric"
         />
       </LabelWrapper>
 

--- a/LAKMobile/src/screens/SignupScreen.tsx
+++ b/LAKMobile/src/screens/SignupScreen.tsx
@@ -1,5 +1,5 @@
-import { StyleSheet, Text, View, TextInput } from 'react-native';
-import { PrimaryButton, LabelWrapper } from '../components';
+import { StyleSheet, View, TextInput } from 'react-native';
+import { PrimaryButton, LabelWrapper, AppText } from '../components';
 import { COLORS } from '../../constants';
 
 export default function SignupScreen({}) {
@@ -48,7 +48,7 @@ export default function SignupScreen({}) {
         />
 
       <View style={styles.loginLinkContainer}>
-        <Text>Already have an account?</Text>
+        <AppText>Already have an account?</AppText>
         <PrimaryButton 
           type='link' 
           title='Log in here' 

--- a/LAKMobile/src/screens/index.tsx
+++ b/LAKMobile/src/screens/index.tsx
@@ -1,2 +1,3 @@
 import SignupScreen from './SignupScreen';
-export { SignupScreen };
+import LoginScreen from './LoginScreen';
+export { SignupScreen, LoginScreen };


### PR DESCRIPTION
### Adminstrative Info
[#5 Sign up page]

### Changes
What changes did you make?
- Added a `PrimaryButton` component which can be reused across different pages
- Added a `LabelWrapper` component to make labelling of input boxes consistent and easy to implement across pages
- Added Sign Up Screen
- Added a custom AppText component which will contain all the typography styles for the App maintaining consistency. 

### Testing
- Manually tested on Android Emulator - Pixel 4 with API 32

### Confirmation of Change

##### PrimaryButton component
<img width="342" alt="Screen Shot 2022-01-18 at 3 58 14 AM" src="https://user-images.githubusercontent.com/56745367/149844170-3e1c206c-aa99-49b4-ba1a-a998a841b7cd.png">

##### Sign up screen (with LabelWrapper)
<img width="375" alt="Screen Shot 2022-01-18 at 3 58 37 AM" src="https://user-images.githubusercontent.com/56745367/149844118-6cd471b0-86b1-48a9-a214-1a6f65213c01.png">
