### PR TITLE
Add ScreenList page to view and test pages while development

### DIFF
--- a/LAKMobile/App.tsx
+++ b/LAKMobile/App.tsx
@@ -2,8 +2,7 @@
 import { MOCK_APPLICANT_DATA } from './constants';
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, View } from 'react-native';
-import { ScreenHeader, ImageCarousel, ApplicantThumbnail } from './src/components';
-import {SignupScreen, LoginScreen, AddJob, ForgotPassword, OTP, ListJobs} from './src/screens';
+import {ScreenList, SignupScreen, LoginScreen, ForgotPassword, OTP, ListJobs, ProfileScreen} from './src/screens';
 import {ResetSuccess} from "./src/screens/ResetSuccess";
 import {ResetPassword} from "./src/screens/ResetPassword";
 import { NavigationContainer } from '@react-navigation/native';
@@ -16,7 +15,7 @@ const Stack = createNativeStackNavigator();
 export default function App() {
   return <View style={styles.container}>
       <NavigationContainer>
-        <Stack.Navigator initialRouteName="ListJobs" screenOptions={{
+        <Stack.Navigator initialRouteName="ScreenList" screenOptions={{
           headerShown: false
         }}>
           <Stack.Screen name="Login" component={LoginScreen} />
@@ -26,6 +25,7 @@ export default function App() {
           <Stack.Screen name="ResetSuccess" component={ResetSuccess} />
           <Stack.Screen name="OTP" component={OTP} />
           <Stack.Screen name="ListJobs" component={ListJobs} />
+          <Stack.Screen name="ScreenList" component={ScreenList} />
         </Stack.Navigator>
       </NavigationContainer>
     </View>

--- a/LAKMobile/src/screens/ForgotPassword.tsx
+++ b/LAKMobile/src/screens/ForgotPassword.tsx
@@ -6,26 +6,25 @@ import {ForgotPasswordProps} from "../types/navigation";
 
 export function ForgotPassword({navigation}: ForgotPasswordProps) {
     return(
-        <View style={styles.container}>
-            <ScreenHeader showArrow={true}>
-                Forgot Pin?
-            </ScreenHeader>
+        <View>
+            <ScreenHeader showArrow={true} children={"Forgot Pin?"}/>
+            <View style={styles.container}>
+                <AppText style={headerText}>Please enter the mobile number associated with your account.</AppText>
 
-            <AppText style={headerText}>Please enter the mobile number associated with your account.</AppText>
+                <LabelWrapper label='Mobile Number'>
+                    <TextInput
+                        style={bigInputStyle}
+                        keyboardType="default"
+                    />
+                </LabelWrapper>
 
-            <LabelWrapper label='Mobile Number'>
-                <TextInput
-                    style={bigInputStyle}
-                    keyboardType="default"
+                <AppButton
+                    type='primary'
+                    title='Submit'
+                    onPress={() => navigation.navigate("OTP")}
+                    style={styles.submitButton}
                 />
-            </LabelWrapper>
-
-            <AppButton
-                type='primary'
-                title='Submit'
-                onPress={() => navigation.navigate("OTP")}
-                style={styles.submitButton}
-            />
+            </View>
         </View>
     )
 }
@@ -34,7 +33,6 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         padding: 32,
-        flex: 1,
         alignItems: 'flex-start',
     },
 
@@ -72,7 +70,6 @@ const bigInputStyle = StyleSheet.flatten([
 
 const headerText = StyleSheet.flatten([{
         width: '100%',
-        marginTop: "30%",
         marginBottom: '8%',
     }
 ]);

--- a/LAKMobile/src/screens/LoginScreen.tsx
+++ b/LAKMobile/src/screens/LoginScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, TextInput, View } from 'react-native';
-import { AppText, LabelWrapper, AppButton } from '../components';
+import { AppText, LabelWrapper, AppButton, ScreenHeader } from '../components';
 import { COLORS } from '../../constants';
 import { NavigationContainer } from '@react-navigation/native';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -8,42 +8,45 @@ import {LoginProps} from '../types/navigation';
 
 export function LoginScreen({navigation}: LoginProps) {
     return(
-        <View style={styles.container}>
-            <LabelWrapper label='Mobile Number'>
-                <TextInput
-                style={bigInputStyle}
-                keyboardType="default"
-                />
-            </LabelWrapper>
+        <View>
+            <ScreenHeader showArrow={true} children={"Login"}/>
+            <View style={styles.container}>
+                <LabelWrapper label='Mobile Number'>
+                    <TextInput
+                    style={bigInputStyle}
+                    keyboardType="default"
+                    />
+                </LabelWrapper>
 
-            <LabelWrapper label='4 Digit PIN'>
-                <TextInput
-                style={smallInputStyle}
-                keyboardType="numeric"
-                />
-            </LabelWrapper>
-            <AppButton 
-                type='link' 
-                title='Forgot PIN?' 
-                onPress={() => navigation.navigate('ForgotPassword')}
-                style={styles.forgotPIN}
-            />
-
-            <AppButton
-                type='primary'
-                title='Log in'
-                onPress={() => loginResponse()}
-                style={styles.submitButton}
-            />
-
-            <View style={styles.signupPrompt}>
-                <AppText>Don't have an account?</AppText>
+                <LabelWrapper label='4 Digit PIN'>
+                    <TextInput
+                    style={smallInputStyle}
+                    keyboardType="numeric"
+                    />
+                </LabelWrapper>
                 <AppButton 
                     type='link' 
-                    title='Sign up here.' 
-                    onPress={() => navigation.navigate('Signup')}
-                    style={styles.signupLink}
+                    title='Forgot PIN?' 
+                    onPress={() => navigation.navigate('ForgotPassword')}
+                    style={styles.forgotPIN}
                 />
+
+                <AppButton
+                    type='primary'
+                    title='Log in'
+                    onPress={() => loginResponse()}
+                    style={styles.submitButton}
+                />
+
+                <View style={styles.signupPrompt}>
+                    <AppText>Don't have an account?</AppText>
+                    <AppButton 
+                        type='link' 
+                        title='Sign up here.' 
+                        onPress={() => navigation.navigate('Signup')}
+                        style={styles.signupLink}
+                    />
+                </View>
             </View>
         </View>
     )
@@ -57,7 +60,6 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         padding: 32,
-        flex: 1,
         alignItems: 'flex-start',
         justifyContent: 'center',
     },

--- a/LAKMobile/src/screens/OTP.tsx
+++ b/LAKMobile/src/screens/OTP.tsx
@@ -6,26 +6,25 @@ import {OTPProps} from '../types/navigation';
 
 export function OTP({navigation}: OTPProps) {
     return(
-        <View style={styles.container}>
-            <ScreenHeader showArrow={true}>
-                OTP Verification
-            </ScreenHeader>
+        <View>
+            <ScreenHeader showArrow={true} children={"OTP Verification"}/>
+            <View style={styles.container}>
+                <AppText style={headerText}>Please enter the OTP sent to your phone.</AppText>
 
-            <AppText style={headerText}>Please enter the OTP sent to your phone.</AppText>
+                <LabelWrapper label='OTP'>
+                    <TextInput
+                        style={smallInputStyle}
+                        keyboardType="default"
+                    />
+                </LabelWrapper>
 
-            <LabelWrapper label='OTP'>
-                <TextInput
-                    style={smallInputStyle}
-                    keyboardType="default"
+                <AppButton
+                    type='primary'
+                    title='Submit'
+                    onPress={() => navigation.navigate("ResetPassword")}
+                    style={styles.submitButton}
                 />
-            </LabelWrapper>
-
-            <AppButton
-                type='primary'
-                title='Submit'
-                onPress={() => navigation.navigate("ResetPassword")}
-                style={styles.submitButton}
-            />
+            </View>
         </View>
     )
 }
@@ -34,7 +33,6 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         padding: 32,
-        flex: 1,
         alignItems: 'flex-start',
     },
 
@@ -72,7 +70,6 @@ const smallInputStyle = StyleSheet.flatten([
 
 const headerText = StyleSheet.flatten([{
         width: '100%',
-        marginTop: "30%",
         marginBottom: '8%',
     }
 ]);

--- a/LAKMobile/src/screens/ResetPassword.tsx
+++ b/LAKMobile/src/screens/ResetPassword.tsx
@@ -6,31 +6,30 @@ import {ResetPasswordProps} from '../types/navigation';
 
 export function ResetPassword({navigation}: ResetPasswordProps) {
     return(
-        <View style={styles.container}>
-            <ScreenHeader showArrow={true}>
-                Forgot Pin?
-            </ScreenHeader>
-            <View style={marginTop}/>
-            <LabelWrapper label='New 4 digit pin'>
-                <TextInput
-                    style={smallInputStyle}
-                    keyboardType="numeric"
-                />
-            </LabelWrapper>
+        <View>
+            <ScreenHeader showArrow={true} children={"Forgot Pin?"}/>
+            <View style={styles.container}>
+                <LabelWrapper label='New 4 digit pin'>
+                    <TextInput
+                        style={smallInputStyle}
+                        keyboardType="numeric"
+                    />
+                </LabelWrapper>
 
-            <LabelWrapper label='Confirm 4 digit pin'>
-                <TextInput
-                    style={smallInputStyle}
-                    keyboardType="numeric"
-                />
-            </LabelWrapper>
+                <LabelWrapper label='Confirm 4 digit pin'>
+                    <TextInput
+                        style={smallInputStyle}
+                        keyboardType="numeric"
+                    />
+                </LabelWrapper>
 
-            <AppButton
-                type='primary'
-                title='Reset Pin'
-                onPress={() => navigation.navigate('ResetSuccess')}
-                style={styles.submitButton}
-            />
+                <AppButton
+                    type='primary'
+                    title='Reset Pin'
+                    onPress={() => navigation.navigate('ResetSuccess')}
+                    style={styles.submitButton}
+                />
+            </View>
         </View>
     )
 }
@@ -39,7 +38,6 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         padding: 32,
-        flex: 1,
         alignItems: 'flex-start',
     },
 
@@ -74,8 +72,3 @@ const smallInputStyle = StyleSheet.flatten([
         width: '45%'
     }
 ])
-
-const marginTop = StyleSheet.flatten([{
-        marginTop: "30%",
-    }
-]);

--- a/LAKMobile/src/screens/ResetSuccess.tsx
+++ b/LAKMobile/src/screens/ResetSuccess.tsx
@@ -6,20 +6,20 @@ import {ResetSuccessProps} from "../types/navigation";
 
 export function ResetSuccess({navigation}: ResetSuccessProps) {
     return(
-        <View style={styles.container}>
-            <ScreenHeader showArrow={true}>
-                Reset Pin
-            </ScreenHeader>
+        <View>
+            <ScreenHeader showArrow={true} children={"Reset Pin"}/>
+            <View style={styles.container}>
+                <AppText style={headerText}>Reset pin successful! You have X reset(s) left this month.</AppText>
 
-            <AppText style={headerText}>Reset pin successful! You have X reset(s) left this month.</AppText>
-
-            <AppButton
-                type='primary'
-                title='Okay'
-                onPress={() => navigation.navigate("Login")}
-                style={styles.submitButton}
-            />
+                <AppButton
+                    type='primary'
+                    title='Okay'
+                    onPress={() => navigation.navigate("Login")}
+                    style={styles.submitButton}
+                />
+            </View>
         </View>
+        
     )
 }
 
@@ -27,7 +27,6 @@ const styles = StyleSheet.create({
     container: {
         width: '100%',
         padding: 32,
-        flex: 1,
         alignItems: 'flex-start',
     },
 
@@ -65,7 +64,6 @@ const bigInputStyle = StyleSheet.flatten([
 
 const headerText = StyleSheet.flatten([{
         width: '100%',
-        marginTop: "30%",
         marginBottom: '8%',
     }
 ]);

--- a/LAKMobile/src/screens/ScreenList.tsx
+++ b/LAKMobile/src/screens/ScreenList.tsx
@@ -1,0 +1,46 @@
+// Note that this page is only for use during development so that every screen can be accessed easily
+// TODO Remove before deploying
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { AppButton, ScreenHeader } from '../components';
+import {RootStackParamList, ScreenListProps} from '../types/navigation';
+
+// Add Page Name to this list to display in list
+const Pages: (keyof RootStackParamList)[] = [
+    'Login',
+    'Signup',
+    'ResetPassword',
+    'ForgotPassword',
+    'ResetSuccess',
+    'OTP',
+];
+
+export function ScreenList({navigation}: ScreenListProps) {
+    return(
+        <View>
+            <ScreenHeader showArrow children={"List of Screens"} />
+            <View style={styles.container}>
+                {
+                    Pages.map((page) => 
+                        <AppButton
+                        key={page}
+                        type='primary'
+                        title={page}
+                        onPress={() => navigation.navigate(page)}
+                    />
+                    )
+                }
+            </View>
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+
+      paddingVertical: 20
+    },
+  });

--- a/LAKMobile/src/screens/SignupScreen.tsx
+++ b/LAKMobile/src/screens/SignupScreen.tsx
@@ -1,61 +1,64 @@
 import { StyleSheet, View, TextInput } from 'react-native';
-import { AppButton, LabelWrapper, AppText } from '../components';
+import { AppButton, LabelWrapper, AppText, ScreenHeader } from '../components';
 import { COLORS } from '../../constants';
 import {SignupProps} from '../types/navigation';
 
 export function SignupScreen({navigation}: SignupProps) {
   return (
-    <View style={styles.container}>
-      <LabelWrapper label='Name (First, Last)'>
-        <TextInput
+    <View>
+      <ScreenHeader showArrow={true} children={"Sign up"}/>
+      <View style={styles.container}>
+        <LabelWrapper label='Name (First, Last)'>
+          <TextInput
           style={styles.input}
           keyboardType="default"
-        />
-      </LabelWrapper>
-      
-      <LabelWrapper label='Mobile Number'>
-        <TextInput
-          style={bigInputStyle}
-          keyboardType="default"
-        />
-      </LabelWrapper>
-
-      <LabelWrapper label='Location'>
-        <TextInput
-          style={bigInputStyle}
-          keyboardType="default"
-        />
-      </LabelWrapper>
-
-      <LabelWrapper label='4 digit pin password'>
-        <TextInput
-          style={smallInputStyle}
-          keyboardType="numeric"
-        />
-      </LabelWrapper>
-
-      <LabelWrapper label='Confirm password'>
-        <TextInput
-          style={smallInputStyle}
-          keyboardType="numeric"
-        />
-      </LabelWrapper>
-
-      <AppButton
-        type='primary'
-        title='Create Account'
-        onPress={() => console.log('Create Account pressed')}
-        style={styles.submitButton}
-        />
-
-      <View style={styles.loginLinkContainer}>
-        <AppText>Already have an account?</AppText>
-        <AppButton 
-          type='link' 
-          title='Log in here' 
-          onPress={() => navigation.navigate('Login')}
-          style={styles.loginLink}
           />
+        </LabelWrapper>
+
+        <LabelWrapper label='Mobile Number'>
+          <TextInput
+          style={bigInputStyle}
+          keyboardType="default"
+          />
+        </LabelWrapper>
+
+        <LabelWrapper label='Location'>
+          <TextInput
+          style={bigInputStyle}
+          keyboardType="default"
+          />
+        </LabelWrapper>
+
+        <LabelWrapper label='4 digit pin password'>
+          <TextInput
+          style={smallInputStyle}
+          keyboardType="numeric"
+          />
+        </LabelWrapper>
+
+        <LabelWrapper label='Confirm password'>
+          <TextInput
+          style={smallInputStyle}
+          keyboardType="numeric"
+          />
+        </LabelWrapper>
+
+        <AppButton
+          type='primary'
+          title='Create Account'
+          onPress={() => console.log('Create Account pressed')}
+          style={styles.submitButton}
+        />
+
+        <View style={styles.loginLinkContainer}>
+          <AppText>Already have an account?</AppText>
+          <AppButton 
+            type='link' 
+            title='Log in here' 
+            onPress={() => navigation.navigate('Login')}
+            style={styles.loginLink}
+          />
+        </View>
       </View>
     </View>
   );
@@ -66,7 +69,6 @@ const styles = StyleSheet.create({
   container: {
     width: '100%',
     padding: 32,
-    flex: 1,
     backgroundColor: COLORS.white,
     alignItems: 'flex-start',
     justifyContent: 'center',

--- a/LAKMobile/src/screens/index.tsx
+++ b/LAKMobile/src/screens/index.tsx
@@ -4,3 +4,4 @@ export * from './AddJob';
 export * from './ForgotPassword';
 export * from './OTP';
 export * from './ListJobs';
+export * from './ScreenList';

--- a/LAKMobile/src/types/navigation.ts
+++ b/LAKMobile/src/types/navigation.ts
@@ -7,6 +7,7 @@ export type RootStackParamList = {
     OTP: undefined;
     ResetSuccess: undefined;
     ForgotPassword: undefined;
+    ScreenList: undefined;
 };
 
 export type LoginProps = NativeStackScreenProps<RootStackParamList, 'Login'>;
@@ -15,3 +16,4 @@ export type ResetPasswordProps = NativeStackScreenProps<RootStackParamList, 'Res
 export type OTPProps = NativeStackScreenProps<RootStackParamList, 'OTP'>;
 export type ResetSuccessProps = NativeStackScreenProps<RootStackParamList, 'ResetSuccess'>;
 export type ForgotPasswordProps = NativeStackScreenProps<RootStackParamList, 'ForgotPassword'>;
+export type ScreenListProps = NativeStackScreenProps<RootStackParamList, 'ScreenList'>;


### PR DESCRIPTION
### Adminstrative Info
[Github Issue #]
This PR adds a screen called ScreenList which links all the Screens we have available for the app. This will be very useful for development because now we can ensure that some change in the code didn't break any part of the app.  

### Changes
What changes did you make?
- Styling changes to add the ScreenHeader consistently with all available pages
<img width="374" alt="Screen Shot 2022-11-28 at 12 42 32 AM" src="https://user-images.githubusercontent.com/56745367/204233185-09305421-487e-40dc-8036-2a2363fc2149.png">

### Testing
How did you confirm your changes worked?
- Tested out all pages with this ScreenList 

### Confirmation of Change
Upload a screenshot, if possible. Othwerwise, please provide instructions on how to see the change.
<img width="370" alt="Screen Shot 2022-11-28 at 12 39 07 AM" src="https://user-images.githubusercontent.com/56745367/204233228-66f3e3cd-4f7d-4841-9fe2-764abedb62ea.png">
<img width="372" alt="Screen Shot 2022-11-28 at 12 39 21 AM" src="https://user-images.githubusercontent.com/56745367/204233229-7768a05d-2fbd-4bd3-9f89-5d0b2de847a2.png">
<img width="369" alt="Screen Shot 2022-11-28 at 12 42 11 AM" src="https://user-images.githubusercontent.com/56745367/204233232-6d666fe5-3e4e-43d0-830b-1ed4556ed89f.png">
<img width="375" alt="Screen Shot 2022-11-28 at 12 42 48 AM" src="https://user-images.githubusercontent.com/56745367/204233267-c9cdb267-270b-47ab-8166-a78a64a16dc1.png">

